### PR TITLE
Fix path to compute small w and h values only when smart is set

### DIFF
--- a/fabric-imgix.html
+++ b/fabric-imgix.html
@@ -528,7 +528,9 @@
         if (!src || typeof(src) === 'undefined' || !ready) {
           return '';
         }
-        if (this.w <= 10 || this.h <= 10) return '';
+
+        if (this.smart && (this.w <= 10 || this.h <= 10)) return '';
+
         let path = `${src}?`;
         const properties = FabricImgix.imgIXProperties;
         let imgIXObject = {};


### PR DESCRIPTION
This closes #7 